### PR TITLE
Fix install service worker async

### DIFF
--- a/src/__tests__/components/__snapshots__/InstallServiceworker-test.js.snap
+++ b/src/__tests__/components/__snapshots__/InstallServiceworker-test.js.snap
@@ -3,7 +3,7 @@
 exports[`InstallServiceworker injects the right script tag 1`] = `
 Array [
   Object {
-    "async": true,
+    "async": "",
     "custom-element": "amp-install-serviceworker",
     "src": "https://cdn.ampproject.org/v0/amp-install-serviceworker-0.1.js",
   },

--- a/src/components/InstallServiceworker.js
+++ b/src/components/InstallServiceworker.js
@@ -32,7 +32,7 @@ class InstallServiceWorker extends Component {
     return (
       <Fragment>
         <Helmet key="helmet">
-          <script async custom-element="amp-install-serviceworker" src="https://cdn.ampproject.org/v0/amp-install-serviceworker-0.1.js" />
+          <script async="" custom-element="amp-install-serviceworker" src="https://cdn.ampproject.org/v0/amp-install-serviceworker-0.1.js" />
         </Helmet>
         <amp-install-serviceworker
           key="install-serviceworker"


### PR DESCRIPTION
The `async` attribute has no value then helmet (most likely, ...anyway something in the middle) transform it to `async="true"` that does not pass the amp-validation